### PR TITLE
ignore debug info and arm stuff to get the right numbers

### DIFF
--- a/analyze_map.py
+++ b/analyze_map.py
@@ -40,6 +40,12 @@ class SectionSize():
     def total(self):
         return self.code + self.data
     def add_section(self, section, size):
+        if section.startswith('.comment'):
+            return
+        if section.startswith('.debug'):
+            return
+        if section.startswith('.ARM.attributes'):
+            return
         if section.startswith('.text'):
             self.code += size
         elif section != '.bss':


### PR DESCRIPTION
The .comment/.debug/Arm.attributes are counted into the data section and thus you get incorrect totals
This simple patch just ignores them. The total at the end are now (more) correct for ro area, on Arm at least
Thank you